### PR TITLE
fix: prevent header overlap on mobile hero text

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,7 +6,7 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-gallery-black">
       <KierkegaardHeader />
-      <main>
+      <main className="pt-24 md:pt-0">
         <ScrollingHero />
         <KierkegaardGrid />
       </main>


### PR DESCRIPTION
## Summary
- add responsive top padding to main to offset fixed header on small screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b56f36e22c832a96f2d2a9e0929a90