### PR TITLE
feat: add mobile header and hero animation

### DIFF
--- a/src/components/KierkegaardHeader.tsx
+++ b/src/components/KierkegaardHeader.tsx
@@ -1,4 +1,3 @@
-import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const KierkegaardHeader = () => {
@@ -6,15 +5,14 @@ const KierkegaardHeader = () => {
     <header className="fixed top-0 left-0 right-0 z-50 p-4 md:p-6">
       <div className="flex items-center justify-between">
         {/* Brand Name - Left */}
-        <div className="text-gallery-white">
-          <h1 className="text-4xl md:text-6xl font-bold tracking-tight uppercase">
-            MEZ
-          </h1>
-        </div>
+        <h1 className="text-xl font-bold tracking-tight uppercase text-gallery-white md:text-6xl">MEZ</h1>
 
-        {/* Navigation - Right */}
-        <div className="flex items-center space-x-6">
-          <nav className="hidden md:flex items-center space-x-8">
+        {/* Mobile Auction Label */}
+        <span className="text-sm uppercase text-gallery-white md:hidden">auction</span>
+
+        {/* Desktop Navigation */}
+        <div className="hidden md:flex items-center space-x-6">
+          <nav className="flex items-center space-x-8">
             <a
               href="#work"
               className="text-sm text-gallery-white hover:text-gallery-white/70 transition-colors"
@@ -34,22 +32,13 @@ const KierkegaardHeader = () => {
               Auctions
             </a>
           </nav>
-          
-          <Button 
-            variant="outline" 
+
+          <Button
+            variant="outline"
             size="sm"
             className="text-xs uppercase tracking-wider border-gallery-white/30 text-gallery-white hover:bg-gallery-white hover:text-gallery-black"
           >
             Contact
-          </Button>
-
-          {/* Mobile Menu Button */}
-          <Button 
-            variant="ghost" 
-            size="sm"
-            className="md:hidden text-gallery-white"
-          >
-            <Menu className="h-4 w-4" />
           </Button>
         </div>
       </div>

--- a/src/components/ScrollingHero.tsx
+++ b/src/components/ScrollingHero.tsx
@@ -1,12 +1,19 @@
 const ScrollingHero = () => {
-  const scrollingItems = [
-    "artist",
-    "auctioneer", 
-    "creator",
-    "artist",
-    "auctioneer",
-    "creator"
-  ];
+  const scrollingItems = Array(6).fill("club mez");
+
+  const renderAnimatedText = (text: string) => (
+    <span className="mx-8 md:mx-16">
+      {text.split('').map((char, idx) => (
+        <span
+          key={idx}
+          className="text-hero text-gallery-white/10 inline-block opacity-0 animate-digital"
+          style={{ animationDelay: `${idx * 0.05}s` }}
+        >
+          {char}
+        </span>
+      ))}
+    </span>
+  );
 
   return (
     <section className="relative min-h-screen overflow-hidden bg-gallery-black">
@@ -17,23 +24,15 @@ const ScrollingHero = () => {
             {/* First set */}
             {scrollingItems.map((item, index) => (
               <div key={`first-${index}`} className="inline-flex items-center">
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  {item}
-                </span>
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  •
-                </span>
+                {renderAnimatedText(item)}
+                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">•</span>
               </div>
             ))}
             {/* Duplicate for seamless loop */}
             {scrollingItems.map((item, index) => (
               <div key={`second-${index}`} className="inline-flex items-center">
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  {item}
-                </span>
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  •
-                </span>
+                {renderAnimatedText(item)}
+                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">•</span>
               </div>
             ))}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -124,6 +124,24 @@
   .delay-400 { animation-delay: 0.4s; }
   .delay-500 { animation-delay: 0.5s; }
 
+  /* Digital letter animation */
+  @keyframes digital-in {
+    0% {
+      opacity: 0;
+      transform: translateY(20px);
+      filter: blur(6px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+      filter: blur(0);
+    }
+  }
+
+  .animate-digital {
+    animation: digital-in 0.6s ease forwards;
+  }
+
   /* Custom utilities */
   .text-gallery-white {
     color: hsl(var(--gallery-white));


### PR DESCRIPTION
## Summary
- tweak mobile header to display small MEZ label on the left and 'auction' text on the right
- update hero background to repeat 'club mez' with letter-by-letter animation
- add digital letter animation styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b571c4efa8832abed9bcb15aafbd8f