### PR TITLE
feat: add mobile header and hero animation

### DIFF
--- a/src/components/KierkegaardHeader.tsx
+++ b/src/components/KierkegaardHeader.tsx
@@ -1,4 +1,3 @@
-import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const KierkegaardHeader = () => {
@@ -6,15 +5,14 @@ const KierkegaardHeader = () => {
     <header className="fixed top-0 left-0 right-0 z-50 p-4 md:p-6">
       <div className="flex items-center justify-between">
         {/* Brand Name - Left */}
-        <div className="text-gallery-white">
-          <h1 className="text-4xl md:text-6xl font-bold tracking-tight uppercase">
-            MEZ
-          </h1>
-        </div>
+        <h1 className="text-xl font-bold tracking-tight uppercase text-gallery-white md:text-6xl">MEZ</h1>
 
-        {/* Navigation - Right */}
-        <div className="flex items-center space-x-6">
-          <nav className="hidden md:flex items-center space-x-8">
+        {/* Mobile Auction Label */}
+        <span className="text-sm uppercase text-gallery-white md:hidden">auction</span>
+
+        {/* Desktop Navigation */}
+        <div className="hidden md:flex items-center space-x-6">
+          <nav className="flex items-center space-x-8">
             <a
               href="#work"
               className="text-sm text-gallery-white hover:text-gallery-white/70 transition-colors"
@@ -34,22 +32,13 @@ const KierkegaardHeader = () => {
               Auctions
             </a>
           </nav>
-          
-          <Button 
-            variant="outline" 
+
+          <Button
+            variant="outline"
             size="sm"
             className="text-xs uppercase tracking-wider border-gallery-white/30 text-gallery-white hover:bg-gallery-white hover:text-gallery-black"
           >
             Contact
-          </Button>
-
-          {/* Mobile Menu Button */}
-          <Button 
-            variant="ghost" 
-            size="sm"
-            className="md:hidden text-gallery-white"
-          >
-            <Menu className="h-4 w-4" />
           </Button>
         </div>
       </div>

--- a/src/components/ScrollingHero.tsx
+++ b/src/components/ScrollingHero.tsx
@@ -1,53 +1,45 @@
 const ScrollingHero = () => {
-  const scrollingItems = [
-    "artist",
-    "auctioneer", 
-    "creator",
-    "artist",
-    "auctioneer",
-    "creator"
-  ];
+  const renderAnimatedLetters = (text: string) => (
+    <span>
+      {text.split('').map((char, idx) => (
+        <span
+          key={idx}
+          className="inline-block opacity-0 animate-digital"
+          style={{ animationDelay: `${idx * 0.05}s` }}
+        >
+          {char}
+        </span>
+      ))}
+    </span>
+  );
 
   return (
-    <section className="relative min-h-screen overflow-hidden bg-gallery-black">
-      {/* Scrolling Text Background */}
-      <div className="absolute inset-0 flex items-center">
-        <div className="whitespace-nowrap">
-          <div className="inline-flex items-center scroll-text">
-            {/* First set */}
-            {scrollingItems.map((item, index) => (
-              <div key={`first-${index}`} className="inline-flex items-center">
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  {item}
-                </span>
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  •
-                </span>
-              </div>
-            ))}
-            {/* Duplicate for seamless loop */}
-            {scrollingItems.map((item, index) => (
-              <div key={`second-${index}`} className="inline-flex items-center">
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  {item}
-                </span>
-                <span className="text-hero text-gallery-white/10 mx-8 md:mx-16">
-                  •
-                </span>
-              </div>
-            ))}
+    <section className="bg-gallery-black">
+      {/* Hero Heading */}
+      <div className="relative flex items-center justify-center min-h-screen">
+        <h2 className="text-hero text-gallery-white uppercase">
+          {renderAnimatedLetters('auction')}
+        </h2>
+
+        {/* Scroll Indicator */}
+        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20">
+          <div className="flex flex-col items-center text-gallery-white/40">
+            <div className="w-px h-12 bg-gallery-white/20 mb-4"></div>
+            <span className="text-xs uppercase tracking-wider transform rotate-90 origin-center whitespace-nowrap">
+              Scroll
+            </span>
           </div>
         </div>
       </div>
 
       {/* Content Grid */}
-      <div className="relative z-10 min-h-screen grid-kierkegaard">
+      <div className="grid-kierkegaard">
         {/* Left Block - Introduction */}
         <div className="bg-gallery-black p-8 md:p-16 flex flex-col justify-center">
           <div className="max-w-md fade-in-up">
             <p className="text-lg md:text-xl text-gallery-white/80 leading-relaxed mb-8">
-              Adelaide contemporary artist pioneering social media art auctions, 
-              bringing unique pieces directly to collectors through innovative 
+              Adelaide contemporary artist pioneering social media art auctions,
+              bringing unique pieces directly to collectors through innovative
               digital platforms.
             </p>
             <div className="space-y-4">
@@ -70,13 +62,13 @@ const ScrollingHero = () => {
               className="w-full h-full object-cover"
             />
           </div>
-          
+
           <div className="space-y-4">
             <h3 className="text-xl text-gallery-white font-medium">
               Current Auction Series
             </h3>
             <p className="text-gallery-white/70 text-sm leading-relaxed">
-              Explore contemporary pieces available through live social media auctions. 
+              Explore contemporary pieces available through live social media auctions.
               Each work represents a unique moment in digital art commerce.
             </p>
             <div className="pt-4">
@@ -91,18 +83,9 @@ const ScrollingHero = () => {
           </div>
         </div>
       </div>
-
-      {/* Scroll Indicator */}
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20">
-        <div className="flex flex-col items-center text-gallery-white/40">
-          <div className="w-px h-12 bg-gallery-white/20 mb-4"></div>
-          <span className="text-xs uppercase tracking-wider transform rotate-90 origin-center whitespace-nowrap">
-            Scroll
-          </span>
-        </div>
-      </div>
     </section>
   );
 };
 
 export default ScrollingHero;
+

--- a/src/index.css
+++ b/src/index.css
@@ -124,6 +124,24 @@
   .delay-400 { animation-delay: 0.4s; }
   .delay-500 { animation-delay: 0.5s; }
 
+  /* Digital letter animation */
+  @keyframes digital-in {
+    0% {
+      opacity: 0;
+      transform: translateY(20px);
+      filter: blur(6px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+      filter: blur(0);
+    }
+  }
+
+  .animate-digital {
+    animation: digital-in 0.6s ease forwards;
+  }
+
   /* Custom utilities */
   .text-gallery-white {
     color: hsl(var(--gallery-white));


### PR DESCRIPTION
## Summary
- tweak mobile header to display small MEZ label on the left and 'auction' text on the right
- display large 'AUCTION' hero heading with letter-by-letter digital animation
- add digital letter animation styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b571c4efa8832abed9bcb15aafbd8f