### PR TITLE
feat: add auction hero with digital reveal

### DIFF
--- a/src/components/AuctionHero.tsx
+++ b/src/components/AuctionHero.tsx
@@ -1,0 +1,21 @@
+const AuctionHero = () => {
+  const title = "AUCTION";
+
+  return (
+    <section className="min-h-screen flex items-center justify-center bg-gallery-black">
+      <h1 aria-label={title} className="flex">
+        {title.split('').map((char, idx) => (
+          <span
+            key={idx}
+            className="text-hero text-gallery-white inline-block opacity-0 animate-digital"
+            style={{ animationDelay: `${idx * 0.1}s` }}
+          >
+            {char}
+          </span>
+        ))}
+      </h1>
+    </section>
+  );
+};
+
+export default AuctionHero;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import KierkegaardHeader from '@/components/KierkegaardHeader';
-import ScrollingHero from '@/components/ScrollingHero';
+import AuctionHero from '@/components/AuctionHero';
 import KierkegaardGrid from '@/components/KierkegaardGrid';
 
 const Index = () => {
@@ -7,7 +7,7 @@ const Index = () => {
     <div className="min-h-screen bg-gallery-black">
       <KierkegaardHeader />
       <main className="pt-24 md:pt-0">
-        <ScrollingHero />
+        <AuctionHero />
         <KierkegaardGrid />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add `AuctionHero` component to display a large AUCTION heading
- show letters with sequential digital reveal animation on the landing page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b574dc7bdc832a88ef7ab08546f00e