### PR TITLE
Guard mock auctions and seed live data

### DIFF
--- a/src/components/BidModal.tsx
+++ b/src/components/BidModal.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface BidModalProps {
   isOpen: boolean;
@@ -24,9 +26,20 @@ export function BidModal({ isOpen, onClose, auction, onBidPlaced }: BidModalProp
   const [bidderPhone, setBidderPhone] = useState('');
   const [bidAmount, setBidAmount] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isDemoAuction = useMemo(() => !UUID_REGEX.test(auction.id), [auction.id]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (isDemoAuction) {
+      toast({
+        title: 'Demo mode',
+        description: 'Bidding is disabled until Supabase is connected.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -145,11 +158,16 @@ export function BidModal({ isOpen, onClose, auction, onBidPlaced }: BidModalProp
             <Button type="button" variant="outline" onClick={onClose} className="flex-1">
               Cancel
             </Button>
-            <Button type="submit" disabled={isSubmitting} className="flex-1">
+            <Button type="submit" disabled={isSubmitting || isDemoAuction} className="flex-1">
               {isSubmitting ? 'Placing Bid...' : 'Place Bid'}
             </Button>
           </div>
         </form>
+        {isDemoAuction && (
+          <p className="pt-4 text-center text-sm text-muted-foreground">
+            These auctions are demo content. Connect Supabase to enable live bidding.
+          </p>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,16 @@
+-- Seed demo auctions that align with edge function validation
+INSERT INTO public.auctions (id, title, artist, description, image_url, starting_bid, current_bid, end_time, status)
+VALUES
+  ('4aaf6322-ab6c-4579-b4bf-79eab904e789', 'Vali Myers Original', 'Vali Myers', 'Original work by Vali Myers', 'vali-myers', 2500, 2500, now() + interval '24 hours', 'live'),
+  ('7ef2c8e9-34a6-499c-aa30-e27daba96436', 'Abstract Emotions', 'Contemporary Artist', 'Vivid exploration of emotion through abstraction.', 'abstract-emotions', 1800, 1800, now() + interval '48 hours', 'live'),
+  ('cab03dab-999c-4d3b-98a8-9592eb7757d2', 'Urban Decay Series', 'Street Artist', 'Limited edition from the Urban Decay collection.', 'urban-decay', 3200, 3200, now() + interval '72 hours', 'live')
+ON CONFLICT (id) DO UPDATE SET
+  title = EXCLUDED.title,
+  artist = EXCLUDED.artist,
+  description = EXCLUDED.description,
+  image_url = EXCLUDED.image_url,
+  starting_bid = EXCLUDED.starting_bid,
+  current_bid = EXCLUDED.current_bid,
+  end_time = EXCLUDED.end_time,
+  status = EXCLUDED.status,
+  updated_at = now();


### PR DESCRIPTION
## Summary
- gate the auctions view to fall back to mock data only when Supabase is unavailable and disable bidding in that mode
- prevent BidModal submissions for non-UUID auctions while showing demo-mode messaging
- seed Supabase with live auction fixtures that comply with edge function validation

## Testing
- npm run lint *(fails: pre-existing no-explicit-any violations in Supabase edge functions)*

------
https://chatgpt.com/codex/tasks/task_b_68e788e30d5c832a8a9aaa49bd27dca6