### PR TITLE
Improve auctions loading state handling

### DIFF
--- a/src/components/Auctions.tsx
+++ b/src/components/Auctions.tsx
@@ -60,6 +60,7 @@ export default function Auctions() {
   };
 
   useEffect(() => {
+    setLoading(true);
     fetchAuctions();
     
     // Subscribe to realtime updates
@@ -73,6 +74,7 @@ export default function Auctions() {
           table: 'auctions'
         },
         () => {
+          setLoading(true);
           fetchAuctions();
         }
       )
@@ -84,6 +86,7 @@ export default function Auctions() {
   }, []);
 
   const fetchAuctions = async () => {
+    setLoading(true);
     try {
       const { data, error } = await supabase
         .from('auctions')
@@ -104,6 +107,7 @@ export default function Auctions() {
   };
 
   const handleBidClick = (auction: Auction) => {
+    setLoading(false);
     setSelectedAuction(auction);
     setIsBidModalOpen(true);
   };


### PR DESCRIPTION
## Summary
- ensure the auctions list sets loading before each fetch on mount and realtime updates
- reset the loading flag when opening the bid modal to keep UI feedback consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e788de6000832abc070529cd779802