### PR TITLE
Fix interactive flows and feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Auctions from "./components/Auctions";
 import EmailSignup from "./components/EmailSignup";
 import Footer from "./components/Footer";
 import { ChatAssistant, ChatButton } from "./components/ChatAssistant";
+import { Toaster } from "./components/ui/toaster";
 
 export default function App() {
   const [loaded, setLoaded] = useState(false);
@@ -19,17 +20,18 @@ export default function App() {
         <EmailSignup />
         <Footer />
       </main>
-      
+
       {/* AI Chat Assistant */}
       {loaded && (
         <>
           <ChatButton onClick={() => setIsChatOpen(true)} />
-          <ChatAssistant 
-            isOpen={isChatOpen} 
-            onClose={() => setIsChatOpen(false)} 
+          <ChatAssistant
+            isOpen={isChatOpen}
+            onClose={() => setIsChatOpen(false)}
           />
         </>
       )}
+      <Toaster />
     </>
   );
 }

--- a/src/components/Auctions.tsx
+++ b/src/components/Auctions.tsx
@@ -17,7 +17,7 @@ interface Auction {
 export default function Auctions() {
   // Mock test data with the 3 artwork images
   const mockAuctions: Auction[] = [{
-    id: '1',
+    id: '7a0b9c2d-2f4d-4a7d-90a1-29d5aef6b101',
     title: 'Vali Myers Original',
     artist: 'Vali Myers',
     image_url: 'vali-myers',
@@ -25,7 +25,7 @@ export default function Auctions() {
     end_time: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     status: 'live'
   }, {
-    id: '2',
+    id: 'e3c70544-9ff9-4f7a-973b-42a6e9ea9f9d',
     title: 'Abstract Emotions',
     artist: 'Contemporary Artist',
     image_url: 'abstract-emotions',
@@ -33,7 +33,7 @@ export default function Auctions() {
     end_time: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
     status: 'live'
   }, {
-    id: '3',
+    id: 'd120a60c-3022-4c8f-9eb2-2df1c9f4d0b5',
     title: 'Urban Decay Series',
     artist: 'Street Artist',
     image_url: 'urban-decay',

--- a/src/components/BidModal.tsx
+++ b/src/components/BidModal.tsx
@@ -97,11 +97,12 @@ export function BidModal({ isOpen, onClose, auction, onBidPlaced }: BidModalProp
       setBidderPhone('');
       setBidAmount('');
       setMaximumBid('');
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error placing bid:', error);
+      const message = error instanceof Error ? error.message : 'Failed to place bid';
       toast({
         title: 'Error',
-        description: error.message || 'Failed to place bid',
+        description: message,
         variant: 'destructive'
       });
     } finally {
@@ -193,7 +194,7 @@ export function BidModal({ isOpen, onClose, auction, onBidPlaced }: BidModalProp
           </div>
 
           <div className="flex gap-3 pt-4">
-            <Button type="button" variant="mez" onClick={onClose} className="flex-1 py-3">
+            <Button type="button" variant="outline" onClick={onClose} className="flex-1 py-3">
               CANCEL
             </Button>
             <Button type="submit" variant="mez" disabled={isSubmitting} className="flex-1 py-3">

--- a/src/components/ChatAssistant.tsx
+++ b/src/components/ChatAssistant.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -107,9 +107,9 @@ export function ChatAssistant({ isOpen, onClose, context }: ChatAssistantProps) 
               </div>
               <div>
                 <DialogTitle>AI Art Assistant</DialogTitle>
-                <p className="text-sm text-muted-foreground">
-                  Powered by ChatGPT
-                </p>
+                <DialogDescription className="text-sm text-muted-foreground">
+                  Powered by ChatGPT. Ask questions about live auctions, bidding rules, or specific artworks.
+                </DialogDescription>
               </div>
             </div>
           </div>
@@ -159,6 +159,7 @@ export function ChatAssistant({ isOpen, onClose, context }: ChatAssistantProps) 
               disabled={isLoading || !inputMessage.trim()}
               variant="mez"
               className="w-12 h-12"
+              aria-label="Send message"
             >
               <Send className="w-4 h-4" />
             </Button>


### PR DESCRIPTION
## Summary
- mount the shared toaster so bid, signup, and chat flows surface their feedback
- update mock auction IDs, bid modal styling, and chat dialog semantics for successful, accessible interactions
- add inline validation to the newsletter form and harden edge-function logging without `any` types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68eb70ed8f70832a9c195673f59ce172